### PR TITLE
Update index.js - Switching between Urls does not clear breadcrumb

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,7 @@ class BreadcrumbsItem_ extends React.Component {
       k => (props[k] !== nextProps[k])
     ).length
     if( differences ) {
+      this.remove(this.props.to, true);
       this.install(nextProps.to, nextProps, true)
     }
   }


### PR DESCRIPTION
In some circumstances the Breadcrumb got not refreshed, but added.

So from "Search" it got "Search / Subcat1" (which is okay), but then switching to Subcat2 it got "Search / Subcat1 / Subcat2". That one line in commit fixed it for me.