### PR TITLE
Updating .codeclimate.yml to include engines

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,16 @@
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - javascript
+  eslint:
+    enabled: true
+  fixme:
+    enabled: true
 ratings:
-   paths:
-   - "src/**"
-exclude_paths:
+  paths:
+  - "src/**"
+exclude_paths: 
+- spec/
 - src/__test__/**/*


### PR DESCRIPTION
Hey, Will from Code Climate here!  As mentioned in our ticket, with this configuration, the analysis is looking at all files in /src.  If you'd like to analyze only /src/index.js, you'll need to change the path to specify only that file.