### PR TITLE
autodetect update mode, update filter, alternate usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ npm install --save react-breadcrumbs-dynamic
 Add a `<BreadcrumbsProvider/>` component to the root of your React component
 tree like you do it for `react-redux` or `react-router`.
 The `BreadcrumbsProvider` component must be parent in react tree of all
-components of this library with any deeps of nesting.
+components of this library with any deeps of nesting. See also
+`Advanced Usage and Performance` section.
 
 ``` javascript
 import {BreadcrumbsProvider} from 'react-breadcrumbs-dynamic'
@@ -49,6 +50,7 @@ const theApp = (
 
 ReactDOM.render(theApp, document.getElementById('root'))
 ```
+
 
 # Instance configuration
 
@@ -94,7 +96,7 @@ contain bearing key with URL for breadcrumbs working. So if you use simple
 `renameProps`, or need to specify both `to` and `href`.
 
 This items configuration method is simple and enough effective. More details
-about performance is described in section Advanced Usage and Performance.
+about performance is described in section `Advanced Usage and Performance`.
 
 Simple configure of the breadcrumbs items:
 
@@ -142,6 +144,7 @@ The result of above code will represent breadcrumbs like this:
   <b to='/user/contacts'>Contacts</b>
 ```
 
+___
 
 # Advanced Usage and Performance
 
@@ -149,7 +152,7 @@ This library does everything possible to make the thing simple and enough
 effective. However, the library cannot know about your application state nor
 can undertake deep inspections of your data to detect changes in efficiency
 considerations. This section describes more effective but more complicated
-way which allows achieve maximum efficiency.
+ways that provides maximum efficiency.
 
 
 ## Avoid to pass arrays/objects/jsx in props of `BreadcrumbsItem`
@@ -193,23 +196,59 @@ render() {
 ```
 
 
-## Best performance
+## Custom update filter
 
-Best performance can be achieved when breadcrumbs items is applied only at time
-of change application data related to breadcrubms. The library provides
-interface for that. The higher order component creation function
-`withBreadcrumbsItem` integrate `breadcrumbs` object with `item()` and `items()`
-functions into props of your `Component`.
+Another way to is to use breadcrumbs item update filter. This is achieved by
+specifying the function in `shouldBreadcrumbsUpdate` param of
+`BreadcrumbsProvider` like this:
+
+``` javascript
+const theApp = (
+  <BreadcrumbsProvider
+    shouldBreadcrumbsUpdate = {
+      (prevProps, props) => {
+        // custom breadcrumbs item update filter condition
+        return prevProps.to != props.to
+      }
+    }
+  />
+    <App />
+  </BreadcrumbsProvider>
+)
+```
+
+The item update filter must make sure that the difference in the params
+is really due to different source data. For example condition
+`{k:'v'} != {k:'v'}` shows that this is the different data, although in
+fact source data is the same and have not changed.
+
+**Warning:** if  update filter will determine the data changing at the
+time when the original data was unchanged this forms an infinite loop.
+
+On the other hand, if some data is not recognized as changed, the breadcrumbs
+will not be updated and will not looks like expected.
+
+
+## Alternate usage
+
+An alternative and more flexible and same time more complicated way is to
+update breadcrumbs only at time of change of application data which related
+to breadcrubms item. The library provides interface for that. The higher order
+component creation function `withBreadcrumbsItem` will integrate `breadcrumbs`
+object with `item()` and `items()` functions into props of your `Component`.
 
 **Warning**: Never call `breadcrumbs.item()` or `breadcrumbs.items()` from
-`render()` or `componentWillUpdate()` methods of your component, nor from
-`constructor()`. This mean breadcrumbs item must be not depend from state of
+`render()` or `componentWillUpdate()` methods or from `constructor()` of your
+component. This mean breadcrumbs item must be not depend from state of
 your current "with breadcrubms" component.
 
 This way allows to specify arrays and objects and react elements (i.e. jsx) in
 props but functions `breadcrumbs.item()` or `breadcrumbs.items()` must be
-called from the `if` statement, where the condition performs checking for
-changes the application data which related to breadcrubms.
+called from the `if` statement, where is the update condition which performs
+checking for changes the application data which related to breadcrubms item.
+
+**Warning:** if update condition will determine the data changing at the time
+when the original data was unchanged this forms an infinite loop.
 
 
 ``` javascript
@@ -226,7 +265,7 @@ class CustomComponent extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    // mandatory required change checking condition
+    // mandatory required update filter condition
     if( this.props.slug !== nextProps.slug ) {
       this.configureBreadcrumbs(nextProps)
     }
@@ -260,7 +299,7 @@ class CustomComponent extends React.Component {
 * `container` - wrapper component (default is `span`)
 * `containerProps` - props for `container` components if defined (default: {})
 * `renameProps` - rename props passed from item intermedator to item
-* `duplicateProps` - duplicate same as `renameProps` but without remove original
+* `duplicateProps` - duplicate same as `renameProps` but without remove original.
 
 
 ## `BreadcrumbsItem` component props
@@ -270,19 +309,23 @@ for `BreadcrumbsItem` will be passed to correspondent breadcrumb component speci
 in `item` or `finalItem` prop of `Breadcrumbs`. Only one prop is mandatory.
 
 * `to` - mandatory required bearing key with URL for breadcrumbs working
-* `...` - any more number of properties
+* `...` - any more number of properties.
 
 
 ## `BreadcrumbsProvider` component props
 
-The `BreadcrumbsProvider` have not props.
+The `BreadcrumbsProvider` props:
+
+* `shouldBreadcrumbsUpdate` - custom breadcrumbs item update filter which is
+the function with two args, where first arg is `prevProps` and second arg is
+`props` - previous and current breadcrumbs item props respectively.
 
 
 ## `withBreadcrumbsItem()` function
 
 This function creates higher order component. It acquire one argument with your
 custom react component and return appropriate component which will have
-`breadcrumbs` in its props with methods `item()` and `items()`
+`breadcrumbs` in its props with methods `item()` and `items()`.
 
 
 ## `this.props.breadcrumbs.item()` and `this.props.breadcrumbs.items()`

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 
 This is completely router-independent react breadcrumbs solution which means
-you can use it with any version of React Router (2 or 3 or 4) or any other
-routing library for React or without routing at all. What you need is just
+that you can use it with any version of React Router (2 or 3 or 4) or any other
+routing library for React or without routing at all. All what you need is just
 to specify components for breadcrumbs items and its props. However props and
-components need to be specified separately. Props need to specify in
+components should be specified separately. Props should be specified in
 intermediator component `BreadcrumbsItem` anywhere in your hierarchy of
 components and routes. Breadcrumbs will be built and (currently) sorted by the
 length of the URL. An application may contain several breadcrumbs with different
@@ -35,9 +35,9 @@ npm install --save react-breadcrumbs-dynamic
 
 Add a `<BreadcrumbsProvider/>` component to the root of your React component
 tree like you do it for `react-redux` or `react-router`.
-The `BreadcrumbsProvider` component must be parent in react tree of all
+In the react tree the `BreadcrumbsProvider` component must be parent of all
 components of this library with any deeps of nesting. See also
-`Advanced Usage and Performance` section.
+*Advanced Usage and Performance* section.
 
 ``` javascript
 import {BreadcrumbsProvider} from 'react-breadcrumbs-dynamic'
@@ -55,10 +55,10 @@ ReactDOM.render(theApp, document.getElementById('root'))
 # Instance configuration
 
 The breadcrumbs instance is implemented in the `Breadcrumbs` component. The
-`Breadcrumbs` component need to be configured, however all params have default
+`Breadcrumbs` component needs to be configured, however all params have default
 value. In this example the `react-router` v4 routing specification is used.
 Please note that `item` and `finalItem` require react component (class) instead
-of react element. However `separator` require react element.
+of react element. However `separator` requires react element.
 
 ``` javascript
 import {Breadcrumbs} from 'react-breadcrumbs-dynamic'
@@ -88,15 +88,13 @@ const Page = (props) => (
 
 # Add item to breadcrumbs
 
-Each routed component in your react tree generally associated with route
+Each routed component in your react tree is generally associated with route
 and with correspondent breadcrumbs. Each component may add its breadcrumbs
-item. The `BreadcrumbsItem` component mandatory require the `to` prop which
-contain bearing key with URL for breadcrumbs working. So if you use simple
+item. The `BreadcrumbsItem` component mandatory requires the `to` prop which
+contains bearing key with URL for breadcrumbs working. So if you use simple
 `<a>` tag for breadcrumb url - you need to use the `duplicateProps` and/or
 `renameProps`, or need to specify both `to` and `href`.
-
-This items configuration method is simple and enough effective. More details
-about performance is described in section `Advanced Usage and Performance`.
+See also *Advanced Usage and Performance* section.
 
 Simple configure of the breadcrumbs items:
 
@@ -148,20 +146,20 @@ ___
 
 # Advanced Usage and Performance
 
-This library does everything possible to make the thing simple and enough
-effective. However, the library cannot know about your application state nor
+This library makes everything possible to make the things simple and effective. 
+However, the library cannot know about your application state nor
 can undertake deep inspections of your data to detect changes in efficiency
-considerations. This section describes more effective but more complicated
-ways that provides maximum efficiency.
+considerations.
 
 
 ## Avoid to pass arrays/objects/jsx in props of `BreadcrumbsItem`
 
-Each time when jsx code like this: `<tag>...</tag>` or `<Component t='...'/>`
-is executed the new react element instance is created, even if you pass same
-props. Also objects or arrays frequently created inplace and represent itself
-new instance which considered as value change event even if it has same values
-in depth.
+When jsx code like this: `<tag>...</tag>` or `<Component t='...'/>`
+is evaluated  the new react element instance is created even if the same props
+was passed. Same thing is when code contains `{}` or `[]` - the new object or
+array is created in-place. All this cases represents new instance which is
+considered as value change event even if this arrays/objects/jsx have same
+values in depth.
 
 The Library does not analyze data into depth to detect changes. So when you
 pass new react element or newly created array or object to `BreadcrumbsItem`
@@ -178,7 +176,7 @@ performance:
 * boolean
 * symbol
 
-So to avoid additional processing does not specify arrays or objects or react
+So to avoid additional processing you should not specify arrays or objects or react
 elements (ie jsx) as props of `BreadcrumbsItem` in `render()` method:
 
 ``` javascript
@@ -198,7 +196,7 @@ render() {
 
 ## Custom update filter
 
-Another way to is to use breadcrumbs item update filter. This is achieved by
+Another way is to use breadcrumbs item update filter. This is achieved by
 specifying the function in `shouldBreadcrumbsUpdate` param of
 `BreadcrumbsProvider` like this:
 
@@ -217,38 +215,38 @@ const theApp = (
 )
 ```
 
-The item update filter must make sure that the difference in the params
-is really due to different source data. For example condition
+The item update filter must guarantee that the difference in the params
+are really due to different source data. For example condition
 `{k:'v'} != {k:'v'}` shows that this is the different data, although in
-fact source data is the same and have not changed.
+fact source data is the same and has not been changed.
 
-**Warning:** if  update filter will determine the data changing at the
-time when the original data was unchanged this forms an infinite loop.
+**Warning:** if update filter determines the data changing at the time when
+the original data has been unchanged this forms an infinite loop.
 
 On the other hand, if some data is not recognized as changed, the breadcrumbs
-will not be updated and will not looks like expected.
+will not be updated and will not look like expected.
 
 
 ## Alternate usage
 
-An alternative and more flexible and same time more complicated way is to
-update breadcrumbs only at time of change of application data which related
-to breadcrubms item. The library provides interface for that. The higher order
+An alternative, more flexible and at the same time more complicated way is to
+update breadcrumbs only when related to breadcrubms item data is changed.
+The library provides interface for that. The higher order
 component creation function `withBreadcrumbsItem` will integrate `breadcrumbs`
 object with `item()` and `items()` functions into props of your `Component`.
 
 **Warning**: Never call `breadcrumbs.item()` or `breadcrumbs.items()` from
 `render()` or `componentWillUpdate()` methods or from `constructor()` of your
-component. This mean breadcrumbs item must be not depend from state of
+component. This means breadcrumbs item must be not depend from state of
 your current "with breadcrubms" component.
 
 This way allows to specify arrays and objects and react elements (i.e. jsx) in
 props but functions `breadcrumbs.item()` or `breadcrumbs.items()` must be
-called from the `if` statement, where is the update condition which performs
-checking for changes the application data which related to breadcrubms item.
+called from the `if` statement, where is the update condition which 
+checks for changes the application related to breadcrubms item data.
 
-**Warning:** if update condition will determine the data changing at the time
-when the original data was unchanged this forms an infinite loop.
+**Warning:** if update condition determines the data changing at the time when
+the original data has been unchanged this forms an infinite loop.
 
 
 ``` javascript
@@ -332,13 +330,13 @@ custom react component and return appropriate component which will have
 
 Methods to configure breadcrumbs item of your current react component.
 These methods will be added to props by HOC of `withBreadcrumbsItem` function.
-The function `item()` accept one react component with props and the functions
+The function `item()` accepts one react component with props and the functions
 `items()` accepts react component with children which may contain any number of
 components to create correspondent number of breadcrumbs item. The breadcrumbs
-item for this functions may be any react component and only props is
+item for these functions may be any react component and only props is
 significant. The `Dummy` and the `Item` components is exported by library
 for this case. Each function accepts null to reset breadcrumbs items to none if
-current component no more needed to represent any breadcrumbs items.
+current component is no more needed to represent any breadcrumbs items.
 
 
 ## LICENSE

--- a/example/src/ToolsPages.js
+++ b/example/src/ToolsPages.js
@@ -8,7 +8,7 @@ const tools_path = base_path+'/tools'
 
 export const Events = ({children}) => (
   <div>
-    <BreadcrumbsItem glyph='calendar' to={tools_path+'/tools'}>
+    <BreadcrumbsItem glyph='calendar' to={tools_path+'/events'}>
       Events
     </BreadcrumbsItem>
     <h2>Events tool Page</h2>
@@ -17,7 +17,7 @@ export const Events = ({children}) => (
 
 export const Statistics = ({children}) => (
   <div>
-    <BreadcrumbsItem glyph='signal' to={tools_path+'/tools'}>
+    <BreadcrumbsItem glyph='signal' to={tools_path+'/statistics'}>
       Statistics
     </BreadcrumbsItem>
     <h2>Statistics tool Page</h2>
@@ -26,7 +26,7 @@ export const Statistics = ({children}) => (
 
 export const Settings = ({children}) => (
   <div>
-    <BreadcrumbsItem glyph='wrench' to={tools_path+'/tools'}>
+    <BreadcrumbsItem glyph='wrench' to={tools_path+'/settings'}>
       Settings
     </BreadcrumbsItem>
     <h2>Settings tool Page</h2>

--- a/package.json
+++ b/package.json
@@ -31,18 +31,18 @@
     "chai": "^4.1.2",
     "codecov": "^2.3.0",
     "enzyme": "^2.9.1",
-    "jest": "^21.0.2",
-    "react": "^15.6.1",
-    "react-addons-test-utils": "^15.6.0",
+    "jest": "^21.2.1",
+    "react": "^15.6.2",
+    "react-addons-test-utils": "^15.6.2",
     "react-bootstrap": "^0.31.2",
-    "react-dom": "^15.6.1",
+    "react-dom": "^15.6.2",
     "react-router-bootstrap": "^0.24.4",
     "react-router-dom": "^4.2.2",
     "webpack": "^3.3.0",
-    "webpack-dev-server": "^2.8.2"
+    "webpack-dev-server": "^2.9.1"
   },
   "dependencies": {
-    "react-broadcast": "^0.4.2"
+    "react-broadcast": "^0.5.2"
   },
   "jest": {
     "moduleDirectories": [

--- a/src/__test__/advanced.spec.js
+++ b/src/__test__/advanced.spec.js
@@ -22,6 +22,7 @@ class WithBreadcrubmsItems extends React.Component {
     breadcrumbs: PropTypes.object,
     haveProfile: PropTypes.bool,
     profileUrl: PropTypes.string,
+    reactComponentInProps: PropTypes.bool,
   }
 
   componentWillMount() {
@@ -29,7 +30,14 @@ class WithBreadcrubmsItems extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.configureBreadcrumbs(nextProps)
+    const keys = Object.keys(nextProps).concat(Object.keys(this.props))
+    const skip = ['breadcrumbs']
+    const differences = keys.filter(
+      k => (!skip.includes(k) && this.props[k] !== nextProps[k])
+    ).length
+    if( differences ) {
+      this.configureBreadcrumbs(nextProps)
+    }
   }
 
   configureBreadcrumbs = (props) => {
@@ -40,9 +48,10 @@ class WithBreadcrubmsItems extends React.Component {
         <Item to='/'>Home</Item>
       )
     } else {
+      const Home = this.props.reactComponentInProps ? <b>Home</b> : 'Home'
       props.breadcrumbs.items(
         <div>
-          <Item to='/'>Home</Item>
+          <Item to='/'>{Home}</Item>
           <Item to='/user'>User</Item>
           { props.haveProfile
             ? <Item to={props.profileUrl}>Profile</Item>
@@ -70,6 +79,7 @@ class TestAdvancedAppComponent extends React.Component {
     duplicateProps: PropTypes.object,
     onlyOneItem: PropTypes.bool,
     noAnyItem: PropTypes.bool,
+    reactComponentInProps: PropTypes.bool,
   }
 
   state = {

--- a/src/__test__/advanced.spec.js
+++ b/src/__test__/advanced.spec.js
@@ -8,7 +8,7 @@ import {
   Breadcrumbs,
   Dummy as Item,
   withBreadcrumbsItem,
-} from '../index';
+} from '../index'
 
 import spec from './index.spec-set'
 

--- a/src/__test__/advanced.spec.js
+++ b/src/__test__/advanced.spec.js
@@ -118,10 +118,17 @@ class TestAdvancedAppComponent extends React.Component {
 }
 
 const TestAdvancedApp = (props) => (
-  <BreadcrumbsProvider>
+  <BreadcrumbsProvider
+    shouldBreadcrumbsUpdate={props.shouldBreadcrumbsUpdate}
+  >
     <TestAdvancedAppComponent {...props}/>
   </BreadcrumbsProvider>
 )
+
+TestAdvancedApp.propTypes = {
+  shouldBreadcrumbsUpdate: PropTypes.func,
+}
+
 
 
 spec(TestAdvancedApp, true)

--- a/src/__test__/advanced.spec.js
+++ b/src/__test__/advanced.spec.js
@@ -62,9 +62,20 @@ class WithBreadcrubmsItems extends React.Component {
     }
   }
 
+  testWrongInstallToKey = () => {
+    this.props.breadcrumbs.install([], {})
+  }
+
+  testWrongInstallPropsType = () => {
+    this.props.breadcrumbs.install(new String('/'), [])
+  }
+
   render() {
     return (
-      <div />
+      <div>
+        <button className="testWrongInstallToKey" onClick={this["testWrongInstallToKey"]} />
+        <button className="testWrongInstallPropsType" onClick={this["testWrongInstallPropsType"]} />
+      </div>
     )
   }
 }

--- a/src/__test__/index.spec-set.js
+++ b/src/__test__/index.spec-set.js
@@ -31,18 +31,6 @@ describe(`breadcrumbs ${usage} usage`, function() {
     expect(wrapper.find('a').at(0).props().to).to.equal('/')
     expect(wrapper.find('a').at(1).props().to).to.equal('/user')
     expect(wrapper.find('a').at(2).props().to).to.equal('/user/profile')
-    wrapper.find('.changeProfileUrl').simulate('click')
-    runAllTimers()
-    expect(wrapper.find('a')).to.have.length(3)
-    expect(wrapper.find('a').at(0).props().to).to.equal('/')
-    expect(wrapper.find('a').at(1).props().to).to.equal('/user')
-    expect(wrapper.find('a').at(2).props().to).to.equal('/user/settings')
-    wrapper.find('.restoreProfileUrl').simulate('click')
-    runAllTimers()
-    expect(wrapper.find('a')).to.have.length(3)
-    expect(wrapper.find('a').at(0).props().to).to.equal('/')
-    expect(wrapper.find('a').at(1).props().to).to.equal('/user')
-    expect(wrapper.find('a').at(2).props().to).to.equal('/user/profile')
     wrapper.unmount()
   })
 
@@ -111,6 +99,41 @@ describe(`breadcrumbs ${usage} usage`, function() {
     expect(wrapper.find('a')).to.have.length(3)
     expect(wrapper.find('b')).to.have.length(1)
     expect(wrapper.find('b').props().children).to.equal('Home')
+    wrapper.unmount()
+  });
+
+  it("support custom update filter", function() {
+    useFakeTimers()
+    const wrapper = mount(<TestApp
+      reactComponentInProps
+      shouldBreadcrumbsUpdate={(prevProps, props) => {
+        return prevProps.to != props.to
+      }}
+    />)
+    runAllTimers()
+    expect(wrapper.find('a')).to.have.length(3)
+    expect(wrapper.find('a').at(2).props().to).to.equal('/user/profile')
+    wrapper.find('.changeProfileUrl').simulate('click')
+    runAllTimers()
+    expect(wrapper.find('a')).to.have.length(3)
+    expect(wrapper.find('a').at(2).props().to).to.equal('/user/settings')
+    wrapper.find('.restoreProfileUrl').simulate('click')
+    runAllTimers()
+    expect(wrapper.find('a')).to.have.length(3)
+    expect(wrapper.find('a').at(2).props().to).to.equal('/user/profile')
+    wrapper.unmount()
+  });
+
+  it("skip update when filtered by custom update filter", function() {
+    useFakeTimers()
+    const wrapper = mount(<TestApp
+      reactComponentInProps
+      shouldBreadcrumbsUpdate={(prevProps, props) => {
+        return false
+      }}
+    />)
+    runAllTimers()
+    expect(wrapper.find('a')).to.have.length(0)
     wrapper.unmount()
   });
 

--- a/src/__test__/index.spec-set.js
+++ b/src/__test__/index.spec-set.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow, mount, render } from 'enzyme'
 import { expect } from 'chai'
-import { Dummy, Item } from '../index'
+import { Dummy, Item, BreadcrumbsProvider, withBreadcrumbsItem } from '../index'
 
 export default function spec(TestApp, advanced) {
 
@@ -162,6 +162,20 @@ describe(`breadcrumbs ${usage} usage`, function() {
     expect(wrapper.find('a').at(1).props().href).to.equal('/user')
     expect(wrapper.find('a').at(2).props().to).to.equal('/user/profile')
     expect(wrapper.find('a').at(2).props().href).to.equal('/user/profile')
+    wrapper.unmount()
+  })
+
+  it("throw in install for wrong types", function() {
+    useFakeTimers()
+    const wrapper = mount(<TestApp/>)
+    expect(wrapper.find('.testWrongInstallToKey')).to.have.length(1)
+    expect(wrapper.find('.testWrongInstallPropsType')).to.have.length(1)
+    expect(() => {
+      wrapper.find('.testWrongInstallToKey').simulate('click')
+    }).to.throw()
+    expect(() => {
+      wrapper.find('.testWrongInstallPropsType').simulate('click')
+    }).to.throw()
     wrapper.unmount()
   })
 

--- a/src/__test__/index.spec-set.js
+++ b/src/__test__/index.spec-set.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow, mount, render } from 'enzyme'
 import { expect } from 'chai'
-import { Dummy, Item } from '../index';
+import { Dummy, Item } from '../index'
 
 export default function spec(TestApp, advanced) {
 
@@ -44,7 +44,7 @@ describe(`breadcrumbs ${usage} usage`, function() {
     expect(wrapper.find('a').at(1).props().to).to.equal('/user')
     expect(wrapper.find('a').at(2).props().to).to.equal('/user/profile')
     wrapper.unmount()
-  });
+  })
 
   it("can remove item", function() {
     useFakeTimers()
@@ -60,7 +60,7 @@ describe(`breadcrumbs ${usage} usage`, function() {
     expect(wrapper.find('a').at(0).props().to).to.equal('/')
     expect(wrapper.find('a').at(1).props().to).to.equal('/user')
     wrapper.unmount()
-  });
+  })
 
   it("can render separator", function() {
     useFakeTimers()
@@ -73,7 +73,7 @@ describe(`breadcrumbs ${usage} usage`, function() {
     expect(wrapper.find('a').at(3).props().children).to.equal('/')
     expect(wrapper.find('a').at(4).props().to).to.equal('/user/profile')
     wrapper.unmount()
-  });
+  })
 
   it("can specify container props", function() {
     useFakeTimers()
@@ -85,28 +85,28 @@ describe(`breadcrumbs ${usage} usage`, function() {
     expect(wrapper.find('a')).to.have.length(3)
     expect(wrapper.find('article')).to.have.length(1)
     expect(wrapper.find('article').at(0).props().data).to.equal('containerProps')
-  });
+  })
 
   it("can render one item", function() {
     useFakeTimers()
-    const wrapper = mount(<TestApp onlyOneItem />);
-    runAllTimers();
-    expect(wrapper.find('a')).to.have.length(1);
+    const wrapper = mount(<TestApp onlyOneItem />)
+    runAllTimers()
+    expect(wrapper.find('a')).to.have.length(1)
     expect(wrapper.find('a').at(0).props().to).to.equal('/')
     wrapper.unmount()
-  });
+  })
 
   it("can render no any item", function() {
     useFakeTimers()
-    const wrapper = mount(<TestApp noAnyItem />);
-    runAllTimers();
-    expect(wrapper.find('a')).to.have.length(0);
+    const wrapper = mount(<TestApp noAnyItem />)
+    runAllTimers()
+    expect(wrapper.find('a')).to.have.length(0)
     wrapper.unmount()
-  });
+  })
 
   it("can rename props", function() {
     useFakeTimers()
-    const wrapper = mount(<TestApp renameProps={{to:"href"}} />);
+    const wrapper = mount(<TestApp renameProps={{to:"href"}} />)
     runAllTimers()
     expect(wrapper.find('a')).to.have.length(3)
     expect(wrapper.find('a').at(0).props()).to.not.have.property("to")
@@ -116,13 +116,13 @@ describe(`breadcrumbs ${usage} usage`, function() {
     expect(wrapper.find('a').at(2).props()).to.not.have.property("to")
     expect(wrapper.find('a').at(2).props().href).to.equal('/user/profile')
     wrapper.unmount()
-  });
+  })
 
   it("can duplicate props", function() {
     useFakeTimers()
-    const wrapper = mount(<TestApp duplicateProps={{to:"href"}} />);
-    runAllTimers();
-    expect(wrapper.find('a')).to.have.length(3);
+    const wrapper = mount(<TestApp duplicateProps={{to:"href"}} />)
+    runAllTimers()
+    expect(wrapper.find('a')).to.have.length(3)
     expect(wrapper.find('a').at(0).props().to).to.equal('/')
     expect(wrapper.find('a').at(0).props().href).to.equal('/')
     expect(wrapper.find('a').at(1).props().to).to.equal('/user')
@@ -130,13 +130,13 @@ describe(`breadcrumbs ${usage} usage`, function() {
     expect(wrapper.find('a').at(2).props().to).to.equal('/user/profile')
     expect(wrapper.find('a').at(2).props().href).to.equal('/user/profile')
     wrapper.unmount()
-  });
+  })
 
   it("have dummy components", function() {
-    expect(Dummy()).to.be.null;
-    expect(Item()).to.be.null;
+    expect(Dummy()).to.be.null
+    expect(Item()).to.be.null
   })
-});
+})
 
 
 } // spec()

--- a/src/__test__/index.spec-set.js
+++ b/src/__test__/index.spec-set.js
@@ -104,6 +104,16 @@ describe(`breadcrumbs ${usage} usage`, function() {
     wrapper.unmount()
   })
 
+  it("pass react component in props", function() {
+    useFakeTimers()
+    const wrapper = mount(<TestApp reactComponentInProps/>)
+    runAllTimers()
+    expect(wrapper.find('a')).to.have.length(3)
+    expect(wrapper.find('b')).to.have.length(1)
+    expect(wrapper.find('b').props().children).to.equal('Home')
+    wrapper.unmount()
+  });
+
   it("can rename props", function() {
     useFakeTimers()
     const wrapper = mount(<TestApp renameProps={{to:"href"}} />)

--- a/src/__test__/simple.spec.js
+++ b/src/__test__/simple.spec.js
@@ -24,6 +24,7 @@ class TestSimpleApp extends React.Component {
     onlyOneItem: PropTypes.bool,
     noAnyItem: PropTypes.bool,
     reactComponentInProps: PropTypes.bool,
+    shouldBreadcrumbsUpdate: PropTypes.func,
   }
 
   state = {
@@ -48,7 +49,9 @@ class TestSimpleApp extends React.Component {
     const noFirstItem = this.props.noAnyItem
     const Home = this.props.reactComponentInProps ? <b>Home</b> : 'Home'
     return (
-      <BreadcrumbsProvider>
+      <BreadcrumbsProvider
+        shouldBreadcrumbsUpdate={this.props.shouldBreadcrumbsUpdate}
+      >
         <div>
           <Breadcrumbs
             separator={this.props.separator}

--- a/src/__test__/simple.spec.js
+++ b/src/__test__/simple.spec.js
@@ -23,6 +23,7 @@ class TestSimpleApp extends React.Component {
     duplicateProps: PropTypes.object,
     onlyOneItem: PropTypes.bool,
     noAnyItem: PropTypes.bool,
+    reactComponentInProps: PropTypes.bool,
   }
 
   state = {
@@ -45,6 +46,7 @@ class TestSimpleApp extends React.Component {
   render() {
     const onlyOneItem = this.props.noAnyItem || this.props.onlyOneItem
     const noFirstItem = this.props.noAnyItem
+    const Home = this.props.reactComponentInProps ? <b>Home</b> : 'Home'
     return (
       <BreadcrumbsProvider>
         <div>
@@ -55,7 +57,7 @@ class TestSimpleApp extends React.Component {
             renameProps={this.props.renameProps}
             duplicateProps={this.props.duplicateProps} />
           { !noFirstItem ?
-            <BreadcrumbsItem to='/'>Home</BreadcrumbsItem>
+            <BreadcrumbsItem to='/'>{Home}</BreadcrumbsItem>
             : null
           }
           { !onlyOneItem ?

--- a/src/__test__/simple.spec.js
+++ b/src/__test__/simple.spec.js
@@ -7,7 +7,7 @@ import {
   BreadcrumbsProvider,
   Breadcrumbs,
   BreadcrumbsItem,
-} from '../index';
+} from '../index'
 
 import spec from './index.spec-set'
 

--- a/src/__test__/simple.spec.js
+++ b/src/__test__/simple.spec.js
@@ -44,6 +44,14 @@ class TestSimpleApp extends React.Component {
     this.setState({haveProfile: false})
   }
 
+  testWrongInstallToKey = () => {
+    this.props.breadcrumbs.install([], {})
+  }
+
+  testWrongInstallPropsType = () => {
+    this.props.breadcrumbs.install(new String('/'), [])
+  }
+
   render() {
     const onlyOneItem = this.props.noAnyItem || this.props.onlyOneItem
     const noFirstItem = this.props.noAnyItem
@@ -76,6 +84,8 @@ class TestSimpleApp extends React.Component {
           <button className="changeProfileUrl" onClick={this["changeProfileUrl"]} />
           <button className="restoreProfileUrl" onClick={this["restoreProfileUrl"]} />
           <button className="removeProfile" onClick={this["removeProfile"]} />
+          <button className="testWrongInstallToKey" onClick={this["testWrongInstallToKey"]} />
+          <button className="testWrongInstallPropsType" onClick={this["testWrongInstallPropsType"]} />
         </div>
       </BreadcrumbsProvider>
     )

--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,7 @@ export class BreadcrumbsProvider extends React.Component {
   install = (to, props, syncUpdate = undefined) => {
     if(
       !( typeof to === 'string' || to instanceof String ) ||
-      !( props instanceof Object )
+      !( props instanceof Object && !(props instanceof Array) )
     ) {
       throw new Error(
         "type error: breadcrumbs.install(to:string, props:Object)"

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ export class BreadcrumbsProvider extends React.Component {
           this.setState({dataNum: this.dataNum})
         }
         this.timer = undefined
-      }, 0);
+      }, 0)
     }
   }
 
@@ -125,7 +125,7 @@ export class BreadcrumbsProvider extends React.Component {
     ) {
       throw new Error(
         "type error: breadcrumbs.install(to:string, props:Object)"
-      );
+      )
     }
 
     const origProps = this.data[to] || {}
@@ -220,8 +220,8 @@ function propsRenAndDup(props, ren, dup) {
 const Breadcrumbs_ = (props) => {
   const {data} = props.breadcrumbs
   const pathnames = Object.keys(data).sort(function(a, b) {
-    return a.length - b.length;
-  });
+    return a.length - b.length
+  })
 
   const Container = props.container || 'span'
   const containerProps = props.containerProps

--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,7 @@ export class BreadcrumbsProvider extends React.Component {
 
     const origProps = this.data[to] || {}
     const keys = Object.keys(origProps).concat(Object.keys(props))
+    // reflect types in the documentation if changed
     const quicks = [ 'string', 'number', 'undefined', 'boolean', 'symbol' ]
     const [diff, comp] = keys.reduce( (stat,k) => {
       return [


### PR DESCRIPTION
I introduce new features:

* add automatic detection of update mode (sync/async) by prop types
* custom update filter: shouldBreadcrumbsUpdate for BreadcrumbsProvider
* alternate usage (described in readme) more flexible and more complicated

and also:

* fix #3 
* update deps
