### PR TITLE
Remove unnecessary dev dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,10 @@
     "gh-pages": "^2.0.1",
     "jest": "^22.4.3",
     "react": "^16.3.2",
-    "react-addons-test-utils": "^15.6.2",
     "react-bootstrap": "^0.32.1",
     "react-dom": "^16.3.2",
     "react-router-bootstrap": "^0.24.4",
     "react-router-dom": "^4.2.2",
-    "react-test-renderer": "^16.3.2",
     "webpack": "^3.10.0",
     "webpack-dev-server": "^2.9.7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4641,10 +4641,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-test-utils@^15.6.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
-
 react-bootstrap@^0.32.1:
   version "0.32.4"
   resolved "https://registry.yarnpkg.com/react-bootstrap/-/react-bootstrap-0.32.4.tgz#8efc4cbfc4807215d75b7639bee0d324c8d740d1"
@@ -4725,7 +4721,7 @@ react-router@^4.3.1:
     prop-types "^15.6.1"
     warning "^4.0.1"
 
-react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.2:
+react-test-renderer@^16.0.0-0:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.6.3.tgz#5f3a1a7d5c3379d46f7052b848b4b72e47c89f38"
   dependencies:


### PR DESCRIPTION
- remove react-test-renderer as a duplicate: used as a dep in `enzyme` projects

- remove react-addons-test-utils as an outdated one:
`This package is deprecated as of version 15.5.0`
source: https://www.npmjs.com/package/react-addons-test-utils